### PR TITLE
Обновить Gradle и зависимости проекта

### DIFF
--- a/API для поиска вакансий.md
+++ b/API для поиска вакансий.md
@@ -5,9 +5,9 @@
 
 ## Документация
 
-С документацией к API для поиска вакансией можно ознакомиться по [этой ссылке](https://practicum-diploma-8bc38133faba.herokuapp.com/docs).
+С документацией к API для поиска вакансией можно ознакомиться по [этой ссылке](https://android-diploma.education-services.ru/docs).
 
 
 ## Получение токена авторизации
 
-Токен для использования API можно получить по [этой ссылке](https://practicum-diploma-8bc38133faba.herokuapp.com/login).
+Токен для использования API можно получить по [этой ссылке](https://android-diploma.education-services.ru/login).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -27,32 +29,29 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-
     buildFeatures {
         buildConfig = true
     }
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+    }
+}
+
 dependencies {
-    implementation(libs.androidX.core)
-    implementation(libs.androidX.appCompat)
+    implementation(libs.core.ktx)
+    implementation(libs.appcompat)
 
     // UI layer libraries
-    implementation(libs.ui.material)
-    implementation(libs.ui.constraintLayout)
+    implementation(libs.material)
+    implementation(libs.constraintlayout)
 
-    // region Unit tests
-    testImplementation(libs.unitTests.junit)
-    // endregion
-
-    // region UI tests
-    androidTestImplementation(libs.uiTests.junitExt)
-    androidTestImplementation(libs.uiTests.espressoCore)
-    // endregion
+    testImplementation(libs.junit4)
+    androidTestImplementation(libs.junit.ext)
+    androidTestImplementation(libs.espresso.core)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.4" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.21" apply false
+    id("com.android.application") version "8.12.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.10" apply false
     id("convention.detekt")
 }

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -1,0 +1,2 @@
+# Gradle Daemon must run on a supported JDK, while the shell may use a newer Java.
+toolchainVersion=21

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,40 +1,48 @@
 [versions]
 
-java = "VERSION_1_8"
-
 # Build constants
+compileSdk = "36"
+java = "VERSION_17"
+material = "1.13.0"
 minSdk = "26"
-compileSdk = "34"
 targetSdk = "33"
 
-# Detekt
-detekt = "1.23.3"
-detektTwitterComposeRules ="0.0.26"
+# AndroidX
+appcompat = "1.7.1"
+constraintlayout = "2.2.1"
+coreKtx = "1.18.0"
+
+# Testing
+espressoCore = "3.5.1"
+junit4 = "4.13.2"
+junitExt = "1.1.5"
+
+# Static analysis
+detekt = "1.23.8"
+detektTwitterComposeRules = "0.0.26"
 
 [libraries]
 
-# Detekt
-staticAnalysis-detektPlugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
-staticAnalysis-detektCli = { module = "io.gitlab.arturbosch.detekt:detekt-cli", version.ref = "detekt" }
+# AndroidX
+appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
+core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+
+# UI
+material = { module = "com.google.android.material:material", version.ref = "material" }
+
+# Testing
+espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
+junit4 = { module = "junit:junit", version.ref = "junit4" }
+junit-ext = { module = "androidx.test.ext:junit", version.ref = "junitExt" }
+
+# Static analysis
 staticAnalysis-detektApi = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detekt" }
-staticAnalysis-detektTest = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detekt" }
+staticAnalysis-detektCli = { module = "io.gitlab.arturbosch.detekt:detekt-cli", version.ref = "detekt" }
 staticAnalysis-detektFormatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 staticAnalysis-detektLibraries = { module = "io.gitlab.arturbosch.detekt:detekt-rules-libraries", version.ref = "detekt" }
+staticAnalysis-detektPlugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
+staticAnalysis-detektTest = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detekt" }
 staticAnalysis-detektTwitterComposeRules = { module = "com.twitter.compose.rules:detekt", version.ref = "detektTwitterComposeRules" }
-
-# AndroidX
-androidX-core = "androidx.core:core-ktx:1.12.0"
-androidX-appCompat = "androidx.appcompat:appcompat:1.6.1"
-
-# UI layer libraries
-ui-material = "com.google.android.material:material:1.10.0"
-ui-constraintLayout = "androidx.constraintlayout:constraintlayout:2.1.4"
-
-# Unit tests
-unitTests-junit = "junit:junit:4.13.2"
-
-# UI tests
-uiTests-junitExt = "androidx.test.ext:junit:1.1.5"
-uiTests-espressoCore = "androidx.test.espresso:espresso-core:3.5.1"
 
 [bundles]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Nov 12 02:07:38 ALMT 2023
+#Thu Mar 12 07:54:29 CET 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Что сделано
- обновлён Gradle wrapper до 8.13
- обновлён Android Gradle Plugin до 8.12.0 с учётом совместимости Android Studio
- обновлён Kotlin Gradle Plugin до 2.3.10 и конфигурация модуля переведена на `compilerOptions`
- повышены `compileSdk` до 36 и Java/Kotlin target до 17
- обновлены AndroidX, Material и Detekt зависимости
- возвращены unit/instrumentation test зависимости
- добавлен `gradle/gradle-daemon-jvm.properties`, чтобы Gradle daemon использовал Java 21 и не падал на системной Java 25
- `gradle/libs.versions.toml` приведён в аккуратный структурированный вид

## Проверка
- `./gradlew build`